### PR TITLE
fix: re-enable github integration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,5 @@
 {
   "cleanUrls": true,
-  "github": {
-    "enabled": true
-  },
   "headers": [
     {
       "source": "/api/og/(.*)",

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "cleanUrls": true,
   "github": {
-    "enabled": false
+    "enabled": true
   },
   "headers": [
     {


### PR DESCRIPTION
## Overview

This pull request re-enables GitHub's integration with Vercel for automated deployments.