### PR TITLE
fix: exclusively use s-maxage

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,7 @@
       "headers": [
         {
           "key": "Cache-Control",
-          "value": "public, max-age=2592000, s-maxage=2588400, stale-while-revalidate=3600"
+          "value": "s-maxage=2592000"
         },  
         {
           "key": "Access-Control-Allow-Origin",


### PR DESCRIPTION
## Overview

This pull request changes the response header from `maxage` caching, which only works in client side, to `s-maxage` as it works with shared requests as intended.