### PR TITLE
fix: use proper vercel recommended caching headers

### DIFF
--- a/api/og/[title].ts
+++ b/api/og/[title].ts
@@ -46,6 +46,10 @@ async function og(
 
   res.setHeader('Content-Length', img.byteLength);
   res.setHeader('Content-Type', `image/${options.format}`);
+  res.setHeader(
+    'Cache-Control',
+    'public, immutable, no-transform, s-maxage=2592000, max-age=2592000'
+  );
 
   return res.status(200).end(img);
 }

--- a/vercel.json
+++ b/vercel.json
@@ -10,10 +10,6 @@
       "source": "/api/og/(.*)",
       "headers": [
         {
-          "key": "Cache-Control",
-          "value": "s-maxage=2592000"
-        },  
-        {
           "key": "Access-Control-Allow-Origin",
           "value": "*"
         },


### PR DESCRIPTION
## Overview

This pull request changes `Cache-Control` headers to match headers written on [the original og-image code](https://github.com/vercel/og-image/blob/main/api/index.ts), albeit with changed expiration time.