### PR TITLE
refactor: move caching header to vercel.json

### DIFF
--- a/api/og/[title].ts
+++ b/api/og/[title].ts
@@ -46,10 +46,6 @@ async function og(
 
   res.setHeader('Content-Length', img.byteLength);
   res.setHeader('Content-Type', `image/${options.format}`);
-  res.setHeader(
-    'Cache-Control',
-    'public, immutable, no-transform, s-maxage=2592000, max-age=2592000'
-  );
 
   return res.status(200).end(img);
 }

--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,10 @@
       "source": "/api/og/(.*)",
       "headers": [
         {
+          "key": "Cache-Control",
+          "value": "public, immutable, no-transform, s-maxage=31536000, max-age=31536000"
+        },
+        {
           "key": "Access-Control-Allow-Origin",
           "value": "*"
         },


### PR DESCRIPTION
## Overview

This pull request migrates the `Cache-Control` header from dynamic code to static `vercel.json`. The reasons for this change are:

1. Only headers set in `vercel.json` that don't interfere with AWS header control mechanism.
2. It's static, never changes. No reason to place it in dynamic part.

Moreover, this code extends the cache duration to one year. Previously, the cache duration is only one month due to [confusion regarding with the documentation](https://vercel.com/docs/concepts/edge-network/caching)